### PR TITLE
build.sh: add build options through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ git clone --recursive https://github.com/loganmc10/m64p.git
 cd m64p
 ./build.sh
 ```
+Build options (environment variables):
+  - `NO_ASM`: set to `0` to enable assembly optimizations in mupen64plus components (default: `1`)
+  - `GLIDE_NOHQ`: set to `On` or `1` to build GLideN64 without realtime texture enhancer library (default: `On`)
+  - `GLIDE_VEC4`: set to `On` or `1` to build GLideN64 with additional VEC4 optimization (default: `On`)
+  - `GLIDE_CRC`: set to `On` or `1` to build GLideN64 using xxHash to calculate texture CRC (default: `On`)

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,10 @@ else
   suffix=".so"
 fi
 
-export NO_ASM=1
+[[ -z $NO_ASM ]] && export NO_ASM=1
+[[ -z $GLIDE_NOHQ ]] && export GLIDE_NOHQ=On
+[[ -z $GLIDE_VEC4 ]] && export GLIDE_VEC4=On
+[[ -z $GLIDE_CRC ]] && export GLIDE_CRC=On
 
 install_dir=$PWD/mupen64plus
 mkdir $install_dir
@@ -66,9 +69,9 @@ make -j4
 
 cd $base_dir/GLideN64/projects/cmake
 if [[ $UNAME == *"MINGW"* ]]; then
-  cmake -G "MSYS Makefiles" -DNOHQ=On -DVEC4_OPT=On -DCRC_OPT=On -DMUPENPLUSAPI=On ../../src/
+  cmake -G "MSYS Makefiles" -DNOHQ=$GLIDE_NOHQ -DVEC4_OPT=$GLIDE_VEC4 -DCRC_OPT=$GLIDE_CRC -DMUPENPLUSAPI=On ../../src/
 else
-  cmake -DNOHQ=On -DVEC4_OPT=On -DCRC_OPT=On -DMUPENPLUSAPI=On ../../src/
+  cmake -DNOHQ=$GLIDE_NOHQ -DVEC4_OPT=$GLIDE_VEC4 -DCRC_OPT=$GLIDE_CRC -DMUPENPLUSAPI=On ../../src/
 fi
 make -j4
 


### PR DESCRIPTION
This will easily allow the user to toggle some build-time options. Useful for packaging.

This will not change the default settings, and will just add the possibility to change some options.

Fell free to close if this is not desired or if this looks weird in someway :)