### PR TITLE
build.sh: exit on error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 UNAME=$(uname -s)
 if [[ $UNAME == *"MINGW"* ]]; then
   suffix=".dll"


### PR DESCRIPTION
The building process currently keeps running when some component fails to build, or if some command fails to execute in someway. This is mostly undesired, because if something fails it should stop the entire building process.

This change makes the building process to stop/exit on the first error.