### PR TITLE
OSX: Add environment variables that fix build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,8 @@ if [[ $UNAME == *"MINGW"* ]]; then
 elif [[ $UNAME == *"Darwin"* ]]; then
   suffix=".dylib"
   gui_dir_suffix=".app/Contents/MacOs/mupen64plus-gui"
+  export CXXFLAGS='-stdlib=libc++'
+  export LDFLAGS='-mmacosx-version-min=10.7'
 else
   suffix=".so"
 fi


### PR DESCRIPTION
There are some cmake errors without these additional environment variables. I forgot to add these earlier.