### PR TITLE
Fix mupen64plus-input-qt INCLUDEPATH

### DIFF
--- a/mupen64plus-input-qt/mupen64plus-input-qt.pro
+++ b/mupen64plus-input-qt/mupen64plus-input-qt.pro
@@ -26,7 +26,7 @@ SOURCES += \
         main.cpp
 
 INCLUDEPATH += \
-        "../../mupen64plus-core/src/api"
+        "../mupen64plus-core/src/api"
 
 HEADERS += \
         osal/osal_dynamiclib.h \


### PR DESCRIPTION
The previous value was reaching outside the project instead of referencing the mupen64plus-core directory in m64p

I discovered this while trying to build locally:

```
g++ -c -pipe -O3 -Wall -Wextra -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I/home/cdb/Projects/personal/n64/m64p/mupen64plus-input-qt -I. -I/home/cdb/Projects/personal/n64/mupen64plus-core/src/api -I/usr/local/include -I/usr/include/SDL2 -I/usr/local/include/SDL2 -I/usr/include/qt -I/usr/include/qt/QtWidgets -I/usr/include/qt/QtGui -I/usr/include/qt/QtNetwork -I/usr/include/qt/QtCore -I. -I/usr/lib/qt/mkspecs/linux-g++ -o moc_configdialog.o moc_configdialog.cpp
/home/cdb/Projects/personal/n64/m64p/mupen64plus-input-qt/main.cpp: In function ‘void setPak(int)’:
/home/cdb/Projects/personal/n64/m64p/mupen64plus-input-qt/main.cpp:671:38: error: ‘struct CONTROL’ has no member named ‘Type’
  671 |     if (controller[Control].control->Type == CONT_TYPE_VRU)
      |                                      ^~~~
/home/cdb/Projects/personal/n64/m64p/mupen64plus-input-qt/main.cpp:671:46: error: ‘CONT_TYPE_VRU’ was not declared in this scope
  671 |     if (controller[Control].control->Type == CONT_TYPE_VRU)
```