### PR TITLE
WIP: RISC-V Support

### DIFF
--- a/mupen64plus-core/projects/unix/Makefile
+++ b/mupen64plus-core/projects/unix/Makefile
@@ -135,6 +135,13 @@ ifneq ("$(filter aarch64,$(HOST_CPU))","")
     PIC ?= 1
     NEW_DYNAREC := 1
 endif
+ifneq ("$(filter riscv64,$(HOST_CPU))","")
+    CPU := RISCV64
+    ARCH_DETECTED := 64BITS
+    PIC ?= 1
+    NO_ASM := 1
+    $(warning Architecture "$(HOST_CPU)" not officially supported.)
+endif
 ifeq ("$(CPU)","NONE")
   $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif


### PR DESCRIPTION
FYI the README needs to be updated to indicate that `libsdl2-net-dev libhidapi-dev` needs to be obtained on Ubuntu, with potentially more. 

Unfortunately I'm not sure what I'm missing here to successfully build the entire repo.
```
ubuntu@ubuntu:~/m64p$ ./build.sh
Makefile:143: Architecture "riscv64" not officially supported.
make: Nothing to be done for 'all'.
make: Nothing to be done for 'all'.
make: Nothing to be done for 'first'.
make: Nothing to be done for 'all'.
current revision "66828afe4d44029b24a94b077e21016db5810f1f"
last build revision "66828afe4d44029b24a94b077e21016db5810f1f"
Project MESSAGE: Not enabling auto updater
make: Nothing to be done for 'first'.
Interprocedural optimizations enabled
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ubuntu/m64p/parallel-rsp/build
[ 42%] Built target lightning
[ 47%] Building CXX object CMakeFiles/mupen64plus-rsp-parallel.dir/parallel.cpp.o
In file included from /home/ubuntu/m64p/parallel-rsp/state.hpp:4,
                 from /home/ubuntu/m64p/parallel-rsp/rsp_op.hpp:4,
                 from /home/ubuntu/m64p/parallel-rsp/rsp_jit.hpp:11,
                 from /home/ubuntu/m64p/parallel-rsp/parallel.cpp:4:
/home/ubuntu/m64p/parallel-rsp/arch/simd/rsp/rsp_common.h:25:10: fatal error: emmintrin.h: No such file or directory
   25 | #include <emmintrin.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/mupen64plus-rsp-parallel.dir/build.make:82: CMakeFiles/mupen64plus-rsp-parallel.dir/parallel.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:124: CMakeFiles/mupen64plus-rsp-parallel.dir/all] Error 2
gmake: *** [Makefile:103: all] Error 2
```